### PR TITLE
Add support for `release.branches` in package.json

### DIFF
--- a/lib/shell/sh-is-release-branch-creation-allowed.js
+++ b/lib/shell/sh-is-release-branch-creation-allowed.js
@@ -16,7 +16,7 @@ module.exports = function (dep) {
             ----------------------------------------------
             Workflow for a Bump PR / Create Release Branch
             ----------------------------------------------
-            1) Execute npx @livingdocsIO/create-bump-pr (see example and option description)
+            1) Execute npx github:livingdocsIO/create-bump-pr (see example and option description)
               - the script automatically updates the README.md with an empty line to indicate a change
               - the script create a PR to incite a new minor version
             2) Go to github and merge the PR

--- a/lib/shell/sh-update-package.js
+++ b/lib/shell/sh-update-package.js
@@ -7,13 +7,21 @@
 module.exports = function (dep) {
   const { exec, logBgYellow, logYellow } = dep
   return function (argv) {
+    let propertyName
     logBgYellow('Update package.json with semantic-release information')
     // const releaseTag = exec(`echo release-$(echo ${argv.baseTag} | cut -d '.' -f1 -f2).x`)
+    // eslint-disable-next-line no-extra-boolean-cast
+    const result = exec(`jq '.release.branches != null' package.json`)
+    if (result.stdout) {
+      propertyName = 'release.branch'
+    } else {
+      propertyName = 'release.branches[0].name'
+    }
     exec(`cat package.json \
-      | jq ".release.branch=\\"${argv.releaseBranchName}\\" \
+      | jq ".${propertyName}=\\"${argv.releaseBranchName}\\" \
       | .publishConfig.tag=\\"${argv.releaseBranchName}\\"" \
       | cat > package.json.tmp && mv package.json.tmp package.json`
     )
-    logYellow('package.json updated')
+    logYellow(`Updated ${propertyName} in package.json`)
   }
 }


### PR DESCRIPTION
Relations:
- PR: https://github.com/livingdocsIO/livingdocs-editor/pull/8711

## Description
Latest version of semantic-release uses `release.branches` instead of `release.branch`, it is already in use in livingdocs-server and livingdocs-editor. This breaks the script during release cut.

I am not sure how to test it. I tested making the logic true and false, but I am not 100% sure the `release.branches[0].name` is the right property to check

## Changelog
- Add support for `release.branches` in package.json

