### PR TITLE
Fix branches when using `create-release-branch` script

### DIFF
--- a/bin/push-feat-commit
+++ b/bin/push-feat-commit
@@ -46,12 +46,17 @@ if [[ $hasUncommitedChanges ]]; then
 fi
 
 
-yellowLog "Initialize the most recent master branch"
+yellowLog "Initialize the most recent main branch"
 git fetch --all
-git checkout master
+if git show-ref --verify --quiet refs/heads/main; then
+  BRANCH="main"
+else
+  BRANCH="master"
+fi
+git checkout $BRANCH
 git reset --hard HEAD
-git pull --rebase origin master
-git reset --hard origin/master
+git pull --rebase origin $BRANCH
+git reset --hard origin/$BRANCH
 
 
 yellowLog "Create a new branch bump-$version"
@@ -70,7 +75,7 @@ git push origin "bump-$version"
 
 
 yellowLog "Delete the local release branch bump-$version"
-git checkout master
+git checkout $BRANCH
 git branch -D "bump-$version"
 
 yellowLog "Create bump pull request"

--- a/bin/tag-publish-docker-image
+++ b/bin/tag-publish-docker-image
@@ -35,8 +35,9 @@ help () {
 }
 
 isReleaseBranch () { [[ $BRANCH_NAME =~ ^release- ]]; }
+isMainBranch () { [[ $BRANCH_NAME == main ]]; }
 isMasterBranch () { [[ $BRANCH_NAME == master ]]; }
-isFeatureBranch () { isMasterBranch && isPullRequest; }
+isFeatureBranch () { (isMasterBranch || isMainBranch) && isPullRequest; }
 isPullRequest () { [[ $PULL_REQUEST_BRANCH != '' ]]; }
 isNotPullRequest () { ! isPullRequest; }
 hasTag () { [[ -n $COMMIT_TAG ]]; }
@@ -126,7 +127,7 @@ if isFeatureBranch; then
   RETURN_VALUE="$FEATURE_TAG"
 fi
 
-if isMasterBranch && isNotPullRequest; then
+if (isMasterBranch || isMainBranch) && isNotPullRequest; then
   log "  Add tags (sha-tag) Add sha-tag to docker image based on the master branch."
   DOCKER_TAGS="$SHA_TAG"
   RETURN_VALUE="$SHA_TAG"

--- a/lib/shell/git-pull-master.js
+++ b/lib/shell/git-pull-master.js
@@ -1,12 +1,14 @@
 module.exports = function (dep) {
   const { exec, logBgYellow } = dep
   return function (argv) {
+    const branchCheck = exec('git show-ref --verify --quiet refs/heads/main; if [ $? -eq 0 ]; then echo main; else echo master; fi', argv.dryRun)
+    const branch = branchCheck.stdout.trim()
     logBgYellow('Initialize the most recent master branch')
     exec('git fetch --all', argv.dryRun)
     exec('git fetch --tags', argv.dryRun)
-    exec('git checkout master', argv.dryRun)
+    exec(`git checkout ${branch}`, argv.dryRun)
     exec('git reset --hard HEAD', argv.dryRun)
-    exec('git pull --rebase origin master', argv.dryRun)
-    exec('git reset --hard origin/master', argv.dryRun)
+    exec(`git pull --rebase origin ${branch}`, argv.dryRun)
+    exec(`git reset --hard origin/${branch}`, argv.dryRun)
   }
 }

--- a/lib/shell/sh-update-package.js
+++ b/lib/shell/sh-update-package.js
@@ -12,10 +12,10 @@ module.exports = function (dep) {
     // const releaseTag = exec(`echo release-$(echo ${argv.baseTag} | cut -d '.' -f1 -f2).x`)
     // eslint-disable-next-line no-extra-boolean-cast
     const result = exec(`jq '.release.branches != null' package.json`)
-    if (result.stdout) {
-      propertyName = 'release.branch'
+    if (result.stdout === 'true') {
+      propertyName = 'release.branches.[0].name'
     } else {
-      propertyName = 'release.branches[0].name'
+      propertyName = 'release.branch'
     }
     exec(`cat package.json \
       | jq ".${propertyName}=\\"${argv.releaseBranchName}\\" \


### PR DESCRIPTION
## Description
During the last release cut we had issues with `create-release-branch` doing the right thing on repositories using `branches` instead of `branch`. This PR addresses the bug to support `branches` and introduces autodetect of `main` branch for repositories that already use it.

## Changelog
- Fix branches logic when running `create-release-branch`
- Autodetect main branch (`master` or `main`) when using commands that require it
